### PR TITLE
F2F-128a: Removed hard coded image value

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -323,8 +323,8 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Essential: true
-          Image: 060113405249.dkr.ecr.eu-west-2.amazonaws.com/di-cic-front:2
-          #Image: "CONTAINER-IMAGE-PLACEHOLDER"
+          # Image: 060113405249.dkr.ecr.eu-west-2.amazonaws.com/di-cic-front:2
+          Image: "CONTAINER-IMAGE-PLACEHOLDER"
           Name: app
           Environment:
             - Name: API_BASE_URL


### PR DESCRIPTION
## Proposed changes
Adjust image id placeholder so it can function correctly with github actions. 

### What changed

Removed hard coded ECR image id value and replaced it with 'CONTAINER-IMAGE-PLACEHOLDER' which can now be referenced by workflow file.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-128](https://govukverify.atlassian.net/browse/F2F-128)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates


[F2F-128]: https://govukverify.atlassian.net/browse/F2F-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[F2F-128]: https://govukverify.atlassian.net/browse/F2F-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ