### PR TITLE
F2F-128a Removing circular reference of export

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -324,14 +324,14 @@ Resources:
       ContainerDefinitions:
         - Essential: true
           # Image: 060113405249.dkr.ecr.eu-west-2.amazonaws.com/di-cic-front:2
-          Image: "CONTAINER-IMAGE-PLACEHOLDER"
+          Image: CONTAINER-IMAGE-PLACEHOLDER
           Name: app
           Environment:
             - Name: API_BASE_URL
               Value: !Sub
                 - "https://${APIGatewayId}.execute-api.eu-west-2.amazonaws.com/${Environment}"
                 - APIGatewayId:
-                    Fn::ImportValue: cic-cri-front-CICFrontGatewayId #Hardcoded, needs to be updated to use a parameter for BE stack name
+                    Fn::ImportValue: test-cic-cri-front-CICFrontGatewayId #Hardcoded, needs to be updated to use a parameter for BE stack name
                   Environment: !Ref Environment
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint

--- a/template.yaml
+++ b/template.yaml
@@ -323,8 +323,8 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Essential: true
-          Image: 060113405249.dkr.ecr.eu-west-2.amazonaws.com/di-cic-front:2
-          #Image: "CONTAINER-IMAGE-PLACEHOLDER"
+          # Image: 060113405249.dkr.ecr.eu-west-2.amazonaws.com/di-cic-front:2
+          Image: "CONTAINER-IMAGE-PLACEHOLDER"
           Name: app
           Environment:
             - Name: API_BASE_URL

--- a/template.yaml
+++ b/template.yaml
@@ -331,7 +331,7 @@ Resources:
               Value: !Sub
                 - "https://${APIGatewayId}.execute-api.eu-west-2.amazonaws.com/${Environment}"
                 - APIGatewayId:
-                    Fn::ImportValue: test-cic-cri-front-CICFrontGatewayId #Hardcoded, needs to be updated to use a parameter for BE stack name
+                    Fn::ImportValue: cic-cri-api-v1-PrivateCICApiGatewayId #Hardcoded, needs to be updated to use a parameter for BE stack name
                   Environment: !Ref Environment
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint
@@ -649,6 +649,9 @@ Resources:
         SSEType: KMS
 
 Outputs:
+  StackName:
+    Description: "CloudFormation stack name"
+    Value: !Sub "${AWS::StackName}"
   CICFrontUrl:
     Description: >-
       The API Gateway URL which CIC Front can be invoked on.


### PR DESCRIPTION
## Proposed changes
Adjusting APIGatewayId to remove circular referencing which is preventing us from updating and deleting stacks. 

### What changed

Adjusted APIGatewayId import value so that it wasn't identical to the export value. 

- [F2F-128](https://govukverify.atlassian.net/browse/F2F-128)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates



[F2F-128]: https://govukverify.atlassian.net/browse/F2F-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[F2F-128]: https://govukverify.atlassian.net/browse/F2F-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ