### PR TITLE
F2F-510b:Removed hardcoded image value

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -329,10 +329,11 @@ Resources:
       ContainerDefinitions:
         - Essential: true
           # Image: 060113405249.dkr.ecr.eu-west-2.amazonaws.com/di-cic-front:2
-          Image: !If 
-            - IsNotDevelopment
-            - CONTAINER-IMAGE-PLACEHOLDER
-            - !Ref DevFrontendContainer
+          Image: CONTAINER-IMAGE-PLACEHOLDER
+          # Image: !If 
+          #   - IsNotDevelopment
+          #   - CONTAINER-IMAGE-PLACEHOLDER
+          #   - !Ref DevFrontendContainer
 
           Name: app
           Environment:


### PR DESCRIPTION
### What changed

Docker image was previously hardcoded for dev as "060113405249.dkr.ecr.eu-west-2.amazonaws.com/di-cic-front:2", removed this value to instead populate with 'CONTAINER-IMAGE-PLACEHOLDER' so that the latest built docker image will also be deployed to the dev environment.

### Why did it change

So that the latest built docker image will also be deployed to the dev environment.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PLAT-510](https://govukverify.atlassian.net/browse/PLAT-510)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates



[PLAT-510]: https://govukverify.atlassian.net/browse/PLAT-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ