### PR TITLE
F2F-510c:Changed APIGatewayId to private export.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -341,7 +341,7 @@ Resources:
               Value: !Sub
                 - "https://${APIGatewayId}.execute-api.eu-west-2.amazonaws.com/${Environment}"
                 - APIGatewayId:
-                    Fn::ImportValue: di-ipv-cri-cic-CICApiGatewayId  #Hardcoded , needs to be updated to use a parameter for BE stack name
+                    Fn::ImportValue: di-ipv-cri-cic-PrivateCICApiGatewayId  #Hardcoded , needs to be updated to use a parameter for BE stack name
                   Environment: !Ref Environment
             # - Name: EXTERNAL_WEBSITE_HOST
             #   Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint


### PR DESCRIPTION
### What changed

Changed the APIGatewayId (for the backend) to the private export: "di-ipv-cri-cic-PrivateCICApiGatewayId"

### Why did it change

Was previously public gateway id export. 

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

