### PR TITLE
Added lower date limit to DOB screen

### DIFF
--- a/src/app/cic/fields.js
+++ b/src/app/cic/fields.js
@@ -99,6 +99,7 @@ module.exports = {
     validate: [
       "required", "date",
       {type: "before", arguments: [new Date().toISOString().split("T")[0]]},
+      {type: "after", arguments: ["1899-01-31"]}
     ]
   }
 };


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/F2F-181

Added lower date limit to input on DOB screen - user can enter dates up to "1-1-1900", any dates before that will throw error.
https://user-images.githubusercontent.com/118540036/213198775-7c3e0d82-2d7b-432d-9f5e-2e06aefcaef4.mov

