### PR TITLE
F2F-231: Removed WAFv2 LoadBalancer association as this is causing a 403 error.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -507,11 +507,11 @@ Resources:
           "responseLength":"$context.responseLength"
           }
 
-  WAFv2ACLAssociation:
-    Type: AWS::WAFv2::WebACLAssociation
-    Properties:
-      ResourceArn: !Ref LoadBalancer
-      WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/WafArn}}"
+  # WAFv2ACLAssociation:
+  #   Type: AWS::WAFv2::WebACLAssociation
+  #   Properties:
+  #     ResourceArn: !Ref LoadBalancer
+  #     WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/WafArn}}"
 
   APIGWAccessLogsGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
### What changed

Removed the WAF/ Load Balancer association resource 

### Why did it change

This resource was causing a 403 error when trying to access our CIC CRI through the IPV Core stub due to the length of the url, removal of this resource removes the limit on the length of the url. 

### Issue tracking

- [F2F-231](https://govukverify.atlassian.net/browse/F2F-231)

## Checklists



[F2F-231]: https://govukverify.atlassian.net/browse/F2F-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ