### PR TITLE
[F2F-342] Fixes validation for past dates for EU Driving Licence

### DIFF
--- a/src/app/cic/steps.js
+++ b/src/app/cic/steps.js
@@ -239,7 +239,7 @@ module.exports = {
     editBackStep: "checkDetails",
     next: [
       {
-        field: "nonUKPassportExpiryDate",
+        field: "euPhotocardDlExpiryDate",
         op: "before",
         value: "today",
         next: "photoIdExpiry",


### PR DESCRIPTION
## Proposed changes
This fixes the bug in [F2F-342](https://govukverify.atlassian.net/browse/F2F-342) which allowed past dates to be entered for the EU Driving Licence

<img width="945" alt="Screenshot 2023-02-21 at 10 48 52" src="https://user-images.githubusercontent.com/117986969/220325100-cd3a7f1d-7706-4470-8ffb-f958f45a21ab.png">

<img width="1043" alt="Screenshot 2023-02-21 at 10 48 58" src="https://user-images.githubusercontent.com/117986969/220325119-d81f45e6-283f-4fbb-809a-25e17f737e07.png">

### Issue tracking

- [F2F-342](https://govukverify.atlassian.net/browse/F2F-342)

## Checklists

### Environment variables or secrets

- [ ] Documented in the README
- [x] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates



[F2F-342]: https://govukverify.atlassian.net/browse/F2F-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[F2F-342]: https://govukverify.atlassian.net/browse/F2F-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ