### PR TITLE
[F2F-343] Fixes 'I do not have any of these documents' link

### DIFF
--- a/src/app/cic/steps.js
+++ b/src/app/cic/steps.js
@@ -82,6 +82,11 @@ module.exports = {
         value: APP.PHOTO_ID_OPTIONS.EU_IDENTITY_CARD,
         next: APP.PATHS.EU_IDENTITY_CARD_DETAILS,
       },
+      {
+        field: "photoIdChoice",
+        value: APP.PHOTO_ID_OPTIONS.NO_PHOTO_ID,
+        next: APP.PATHS.NO_PHOTO_ID,
+      },
     ],
   },
 


### PR DESCRIPTION
## Proposed changes
Updates the link for the the 'I do not have any of these documents' radio button on the document selection screen as per  [F2F-343](https://govukverify.atlassian.net/browse/F2F-343)

<img width="815" alt="Screenshot 2023-02-21 at 11 16 25" src="https://user-images.githubusercontent.com/117986969/220330928-6159282a-0241-42e9-9a2b-81f6a150597f.png">

<img width="1510" alt="Screenshot 2023-02-21 at 11 19 10" src="https://user-images.githubusercontent.com/117986969/220331197-003a3796-fd51-46a1-8f5a-d851f3573ec4.png">

### Why did it change

The link wasn't working correctly before

### Issue tracking
- [F2F-343](https://govukverify.atlassian.net/browse/F2F-343)

## Checklists
- [ ] Documented in the README
- [x] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates


[F2F-343]: https://govukverify.atlassian.net/browse/F2F-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[F2F-343]: https://govukverify.atlassian.net/browse/F2F-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ