### PR TITLE
F2F-354 Name Entry missing value test

### DIFF
--- a/test/browser/features/BrowserBasedTests/UnHappyPath/InlineValidation/CICNameEntryScreenMissValue.feature
+++ b/test/browser/features/BrowserBasedTests/UnHappyPath/InlineValidation/CICNameEntryScreenMissValue.feature
@@ -1,0 +1,25 @@
+@mock-api:f2f-cic-success
+Feature: The user enters their name to be used as part of their claimed identity
+
+
+    Background:
+        Given Authenticatable Anita is using the system
+        When they have provided their details
+        Then they should be redirected to the landingPage
+
+        Given the user wants to progress to the next step of the journey
+        When the user clicks the continue button on the LandingPage
+        Then the user is routed to the next screen in the journey PhotoId Selection
+
+        Given the BRP option is selected
+        When the user clicks the BRP continue button
+        Then the user is routed to the next screen in the journey BRP Expiry Date
+
+        Given the date entered is within accepted BRP expiration window
+        When the user clicks the continue button on the BRP Page
+        Then the user is routed to the next screen in the BRP journey - Name Entry
+
+    Scenario: Successful validation of Surname and First name fields
+        Given only one mandatory name field has been entered
+        When the user clicks the continue button in the NameEntry screen
+        Then the user sees an inline error message displayed in the NameEntry screen

--- a/test/browser/pages/nameEntryPage.js
+++ b/test/browser/pages/nameEntryPage.js
@@ -31,6 +31,10 @@ module.exports = class PlaywrightDevPage {
       await this.page.click("#back");
     }
     
+    async checkErrorText(){
+      const errorText = await this.page.locator("#error-summary-title").textContent();
+      return errorText.trim(); 
+    }
   };
 
   

--- a/test/browser/step_definitions/CICNameEntryMissValue.step.js
+++ b/test/browser/step_definitions/CICNameEntryMissValue.step.js
@@ -1,0 +1,38 @@
+const { Given, When, Then} = require("@cucumber/cucumber");
+
+const { expect } = require("chai");
+
+const { NameEntryPage }  = require("../pages");
+       
+Given(/^only one mandatory name field has been entered$/, async function () {
+    const nameEntryPage = new NameEntryPage(await this.page);
+
+    await nameEntryPage.enterSurname();
+    await nameEntryPage.enterMiddleName();
+
+  }
+);
+
+When(
+  /^the user clicks the continue button in the NameEntry screen$/, async function () {
+  const nameEntryPage = new NameEntryPage(await this.page);
+  
+  await nameEntryPage.continue();
+
+});
+
+Then(
+  /^the user sees an inline error message displayed in the NameEntry screen$/,
+  async function () {
+    const nameEntryPage = new NameEntryPage(await this.page);
+
+    expect(await nameEntryPage.isCurrentPage()).to.be.true;
+
+    const inlineError = 'There is a problem';
+
+    const error = await nameEntryPage.checkErrorText();
+      
+    expect(await error).to.equal(inlineError);
+    
+  }
+);


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXXX] PR Title` -->

### What changed

<!-- Missing vale check for Name Entry screen - feature and step definition files created-->

### Why did it change

<!-- Part of the Inline Error UnHappy Path checking -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-354](https://govukverify.atlassian.net/browse/F2F-354)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->

[F2F-354]: https://govukverify.atlassian.net/browse/F2F-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ