### PR TITLE
F2F-602 configure autoscaling policies for FE

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ yarn install
 - 'BASE_URL': Externally accessible base url of the webserver. Used to generate the callback url as part of credential issuer oauth flows
 - `PORT` - Default port to run webserver on. (Default to `5020`)
 
+# Deployment in own stack in DEV
+
+To deploy a copy of the frontend infra from a local branch as a separate isolated stack in DEV:
+
+- update the `Image:` tag in template.yaml to point to the container image to be deployed - this can be found by looking in ECR in the AWS Console for the latest image and tag.
+- the run:
+
+```shell
+sam build --parallel --no-cached
+sam deploy --resolve-s3 --stack-name "CUSTOM_STACK_NAME" --capabilities CAPABILITY_IAM --confirm-changeset --parameter-overrides \
+"Environment=\"dev\" PermissionsBoundary=\"none\" VpcStackName=\"vpc-cri\" EnableScalingInDev=0"
+```
+
+Note the following parameters can be used to specify whether or not to deploy the autoscaling infra:
+
+- `EnableScalingInDev` default to 0 which inhibits deployment of scaling infra in dev; set to 1 to deploy scaling infra
+- `MinContainerCount` default is 3
+- `MaxContainerCount` default is 12
+
 # Mock Data
 
 [Wiremock](https://wiremock.org/) has been used to create a [stateful mock](https://wiremock.org/docs/stateful-behaviour/) of the API, through the use of scenarios. These configuration files are stored as JSON files in the [./test/mocks/mappings](./test/mocks/mappings) directory.

--- a/template.yaml
+++ b/template.yaml
@@ -34,6 +34,18 @@ Parameters:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
     Default: "none"
+  MaxContainerCount:
+    Description: Maximum number of FE node/express container tasks to allow autoscaling to reach
+    Type: Number
+    Default: 12
+  MinContainerCount:
+    Description: Minimum number of FE node/express container tasks to allow autoscaling to reach
+    Type: Number
+    Default: 3
+  EnableScalingInDev:
+    Type: Number
+    Default: 0
+    Description: Set to 1 to enable deployment of scaling infra in dev
 
 Conditions:
   IsNotDevelopment: !Or
@@ -41,7 +53,12 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
-  IsProduction: !Equals [ !Ref Environment, production ]
+  EnableScaling: !Or
+    - !Equals [ !Ref EnableScalingInDev, 1]
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -267,7 +284,7 @@ Resources:
         DeploymentCircuitBreaker:
           Enable: TRUE
           Rollback: TRUE
-      DesiredCount: 2
+      DesiredCount: !Ref MinContainerCount
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
@@ -348,9 +365,9 @@ Resources:
               awslogs-group : !Ref ECSAccessLogsGroup
               awslogs-region : !Sub ${AWS::Region}
               awslogs-stream-prefix : !Sub cic-front-${Environment}
-      Cpu: '256'
+      Cpu: '1024'
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
-      Memory: '512'
+      Memory: '2048'
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
@@ -522,11 +539,11 @@ Resources:
   # Scaling down will occur after 15 minutes of 90% utilization of the configured CPU utilization.
 
   ECSAutoScalingTarget:
-    Condition: IsProduction
+    Condition: EnableScaling
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: 3
-      MinCapacity: 1
+      MaxCapacity: !Ref MaxContainerCount
+      MinCapacity: !Ref MinContainerCount
       ResourceId: !Join
         - '/'
         - - "service"
@@ -537,7 +554,7 @@ Resources:
       ServiceNamespace: ecs
 
   ECSAutoScalingPolicy:
-    Condition: IsProduction
+    Condition: EnableScaling
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
@@ -553,7 +570,9 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 70.0
+        TargetValue: 50.0
+        ScaleInCooldown: 0
+        ScaleOutCooldown: 0
 
   ### www domain
 


### PR DESCRIPTION
## Proposed changes

### What changed

Configure the ECS autoscaling policies as described in ticket in order to ensure correct scaling under load.

### Why did it change

During a load test in w/c 8th May it was found the FE did not scale properly under load.

### Issue tracking

- [F2F-602](https://govukverify.atlassian.net/browse/F2F-602)

## Checklists

### Environment variables or secrets

- [x] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations


[F2F-602]: https://govukverify.atlassian.net/browse/F2F-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ