### PR TITLE
F2F-659 add responseLatency and integrationLatency to FE APIGW Access Log

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -509,7 +509,9 @@ Resources:
           "routeKey":"$context.routeKey",
           "status":"$context.status",
           "protocol":"$context.protocol",
-          "responseLength":"$context.responseLength"
+          "responseLength":"$context.responseLength",
+          "responseLatency":"$context.responseLatency",
+          "integrationLatency":"$context.integrationLatency"
           }
 
   # WAFv2ACLAssociation:


### PR DESCRIPTION
## Proposed changes

### What changed

add responseLatency and integrationLatency to FE APIGW Access Log

### Why did it change

assist in reviewing performance test results

### Issue tracking

- [F2F-659](https://govukverify.atlassian.net/browse/F2F-659)


[F2F-659]: https://govukverify.atlassian.net/browse/F2F-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ