### PR TITLE
[F2F-926] - Family name to single string 

### DIFF
--- a/src/app/cic/controllers/checkDetails.js
+++ b/src/app/cic/controllers/checkDetails.js
@@ -23,7 +23,6 @@ class CheckDetailsController extends DateController {
       locals.formattedBirthDate = formatDate(dateOfBirth, "YYYY-MM-DD");
       locals.changeUrl = `/${changeUrl}`;
       locals.fullName = fullName
-
       callback(err, locals);
     });
   }

--- a/src/app/cic/fields.js
+++ b/src/app/cic/fields.js
@@ -4,7 +4,7 @@ module.exports = {
     journeyKey: "surname",
     validate: [
       "required",
-      { type: "regexName", fn: (value) => value.match(/^[a-zA-Z .'-]*$/) }
+      { type: "regexName", fn: (value) => value.match(/^[a-zA-Z.'-]+( [a-zA-Z.'-]+)*$/) }
     ]
   },
   firstName: {
@@ -12,7 +12,7 @@ module.exports = {
     journeyKey: "firstName",
     validate: [
       "required",
-      { type: "regexName", fn: (value) => value.match(/^[a-zA-Z .'-]*$/) }
+      { type: "regexName", fn: (value) => value.match(/^[a-zA-Z.'-]+( [a-zA-Z.'-]+)*$/) }
     ]
   },
   middleName: {


### PR DESCRIPTION
### What changed

Functionally, nothing. The regex was updated for the first and last names to align with what's now on the backend. 

![Screenshot 2023-07-14 at 10 57 47](https://github.com/alphagov/di-ipv-cri-cic-front/assets/117986969/44b5966b-da56-451b-9837-dd2582af3ded)
![Screenshot 2023-07-14 at 10 57 57](https://github.com/alphagov/di-ipv-cri-cic-front/assets/117986969/be019701-e915-4cae-9059-f82bbabb78d5)

### Why did it change

The regex worked with the wizard on the FE, but on the BE wasn't sufficient to meet the validation requirements. 

### Issue tracking

- [F2F-926](https://govukverify.atlassian.net/browse/F2F-926)