### PR TITLE
F2F-967 Switched from npm to yarn

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,6 +11,6 @@ COPY . /app
 WORKDIR /app
 COPY run-tests.sh /
 RUN chmod +x /run-tests.sh
-RUN cd /app && npm ci
+RUN cd /app && yarn install
 
 ENTRYPOINT ["/run-tests.sh"]


### PR DESCRIPTION
## Proposed changes
Switch the Dockerfile.test from npm to yarn.

### What changed

As there is no package-lock.json, the `npm ci` command fails.  There is a yarn.lock, so this project should be setup to use yarn, not npm.



### Issue tracking
- [F2F-967](https://govukverify.atlassian.net/browse/F2F-967)

