### PR TITLE
Shell script incorrectly reference app directory in cwd

### DIFF
--- a/run-tests-locally.sh
+++ b/run-tests-locally.sh
@@ -30,7 +30,7 @@ then
     docker images $DockerImageName -q |xargs docker rmi
 
     docker build -f Dockerfile.test -t $DockerImageName .
-    docker run --rm --env-file docker_vars.env -v $(pwd)/results:/results $DockerImageName
+    docker run --rm --env-file docker_vars.env -v $(pwd)/test/reports:/results $DockerImageName
 else    
     echo "Please ensure you've got a stack name as the first argument after ./run_tests_locally.sh..."
     echo "E.g. ./run_tests_locally.sh cri-cic-api"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,12 +8,11 @@ remove_quotes () {
   echo "$1" | tr -d '"'
 }
 
-declare error_code
 # Github actions set to true for tests to run in headless mode
 export GITHUB_ACTIONS=true
 # shellcheck disable=SC2154
 export IPV_STUB_URL=$(remove_quotes $CFN_CICIPVStubExecuteURL)start
 
-cd ./app; yarn run test:browser:ci
+cd /app; yarn run test:browser:ci
 
 cp -rf /app/test/reports $TEST_REPORT_ABSOLUTE_DIR


### PR DESCRIPTION
### What changed

Updated the run-tests script to use absolute path.

### Why did it change

Tests fail in the pipeline.

### Issue tracking

- [F2F-973](https://govukverify.atlassian.net/browse/F2F-973)

## Checklists

### Environment variables or secrets

Test output
![image](https://github.com/alphagov/di-ipv-cri-cic-front/assets/133013208/adfc9442-8fee-42ce-afa4-aa4cbefbf137)
