### PR TITLE
F2F-1117: cri-cic-front repository does not report coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,4 @@ deploy/.aws-sam/
 deploy/samconfig.toml
 wafv2/
 package-lock.json
-reports
-test/reports/
 .aws-sam/
-app


### PR DESCRIPTION

<img width="1482" alt="Screenshot 2023-08-18 at 15 46 26" src="https://github.com/alphagov/di-ipv-cri-cic-front/assets/131283983/0c1f77c7-e323-4433-a239-2739e524140d">
- Modified the github workflow test coverage pattern.

- [F2F-1117](https://govukverify.atlassian.net/browse/F2F-1117)


[F2F-1117]: https://govukverify.atlassian.net/browse/F2F-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ