### PR TITLE
F2F-1135 Update TESTHARNESS in BUILD main template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -113,7 +113,7 @@ Mappings:
       SESSIONTABLENAME: "cic-front-sessions-build"
       GTMID: "TK92W68"
       ANALYTICSDOMAIN: "build.account.gov.uk"
-      TESTHARNESSURL: "https://cic-test-harness-testharness.review-c.build.account.gov.uk"
+      TESTHARNESSURL: "https://testharness.review-c.build.account.gov.uk"
       BACKENDURL: "https://api.review-c.build.account.gov.uk"
       BACKENDSESSIONTABLE: "session-cic-cri-ddb"
     staging:


### PR DESCRIPTION
## Proposed changes

### What changed

TESTHARNESS definition in build main template

### Why did it change

was previously incorrect causing the test-container in build to fail and the pipeline to be blocked

### Issue tracking

- [F2F-1135](https://govukverify.atlassian.net/browse/F2F-1135)

## Checklists

### PII logging

- [X] Verified that no PII data is being logged

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-1135]: https://govukverify.atlassian.net/browse/F2F-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ